### PR TITLE
Config validate

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -77,9 +77,7 @@ impl Config {
     /// Lightly validates config_map values. This mostly exists to limit the
     /// size of `Config::init`.
     fn validate(key: &str, config_map: &HashMap<String, bool>) -> bool {
-        config_map.get::<str>(key).map_or(false,|value| {
-            *value
-        })
+        config_map.get::<str>(key).map_or(false, |value| *value)
     }
 
     /// Very basic parsing function based on a very basic configuration file.

--- a/src/config.rs
+++ b/src/config.rs
@@ -77,10 +77,9 @@ impl Config {
     /// Lightly validates config_map values. This mostly exists to limit the
     /// size of `Config::init`.
     fn validate(key: &str, config_map: &HashMap<String, bool>) -> bool {
-        match config_map.get::<str>(key) {
-            Some(value) => *value,
-            None => false,
-        }
+        config_map.get::<str>(key).map_or(false,|value| {
+            *value
+        })
     }
 
     /// Very basic parsing function based on a very basic configuration file.


### PR DESCRIPTION
This commit utilizes the `map_or` method available on an `Option` type. It is a little less verbose and encodes the idea that `false` is a _default_ value.

```rust
// signature
pub fn map_or<U, F>(self, default: U, f: F) -> U { ... }
```
From:
```rust
    fn validate(key: &str, config_map: &HashMap<String, bool>) -> bool {
        match config_map.get::<str>(key) {
            Some(value) => *value,
            None => false,
        }
}
```
To:
```rust
    fn validate(key: &str, config_map: &HashMap<String, bool>) -> bool {
        config_map.get::<str>(key).map_or(false, |value| *value)
    }
```