### PR TITLE
Update authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bifrost"
 version = "0.1.0"
-authors = ["ericdeansanchez <ericdeansanchez@berkeley.edu>"]
+authors = ["ericdeansanchez <ericdeansanchez@berkeley.edu>", "parkerduckworth <parker_duckworth@icloud.com>"]
 edition = "2018"
 
 [dependencies]

--- a/src/app.rs
+++ b/src/app.rs
@@ -32,7 +32,7 @@ pub fn app() -> App {
     let mut app = App::new("bifrost")
         .about("Bridging the tool gap")
         .version("0.1")
-        .author(crate_authors!())
+        .author(crate_authors!(",\n"))
         .template(APP_TEMPLATE)
         .usage(BIFROST_USAGE);
 

--- a/src/template.rs
+++ b/src/template.rs
@@ -47,7 +47,7 @@ pub const EXPLICIT_LONG_HELP: &str = "
 
 
 AUTHORS:
-ericdeansanchez <ericdeansanchez@berkeley.edu>
+ericdeansanchez <ericdeansanchez@berkeley.edu>:parkerduckworth <parker_duckworth@icloud.com>
 
 ABOUT:
 Bridging the tool gap

--- a/src/template.rs
+++ b/src/template.rs
@@ -47,7 +47,8 @@ pub const EXPLICIT_LONG_HELP: &str = "
 
 
 AUTHORS:
-ericdeansanchez <ericdeansanchez@berkeley.edu>:parkerduckworth <parker_duckworth@icloud.com>
+ericdeansanchez <ericdeansanchez@berkeley.edu>,
+parkerduckworth <parker_duckworth@icloud.com>
 
 ABOUT:
 Bridging the tool gap


### PR DESCRIPTION
## Changes
- Added myself as an author

## Details
- When I first changed the author list in `Cargo.toml`, `test_basic_help` failed

- This was because clap was rendering the authors for the `--help` option in an awkward fashion: 
```sh
author1 <author1@email.com>:author2 <author2@email.com>
```
 - I found in the [clap docs](https://docs.rs/clap/2.33.0/clap/macro.crate_authors.html) that throwing `",\n"` in as an argument to the `crate_authors!()` macro stacks the author names in a more aesthetic way.