### PR TITLE
Multiple positional args

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -127,6 +127,7 @@ detected and loaded into the bifrost container without having to manually run \
 ";
 
     let a = Arg::with_name("auto")
+        .multiple(true)
         .long("auto")
         .short("a")
         .help(SHORT)
@@ -142,7 +143,7 @@ fn arg_load_contents(args: &mut Vec<Arg>) {
     const LONG: &str = "Directory, files, or singular file to load into the \
                         bifrost container.";
 
-    let a = Arg::with_name("contents").help(LONG).long_help(LONG);
+    let a = Arg::with_name("contents").multiple(true).help(LONG).long_help(LONG);
 
     args.push(a);
 }
@@ -156,6 +157,7 @@ fn arg_load_modified(args: &mut Vec<Arg>) {
          not entirely sure if we're going to keep this behavior.";
 
     let a = Arg::with_name("modified")
+        .multiple(true)
         .long("modified")
         .short("m")
         .help(SHORT)

--- a/src/command.rs
+++ b/src/command.rs
@@ -6,7 +6,8 @@ use crate::workspace::WorkSpace;
 pub fn load(workspace: &WorkSpace, contents: &ArgMatches<'static>) {
     // If contents specifies a valid directory, file, or files then load these
     // contents into the container. Otherwise, load the entire `WorkSpace`
-    println!("[STUB] command::load() contents: {:#?}", contents);
+    let args = contents.values_of("contents");
+    println!("[STUB] command::load() contents: {:?}", args)
 }
 
 pub fn unload() {


### PR DESCRIPTION
## Changes
All load args can now handle multiple positional arguments.  

## Details
I also changed the stub in `load` to display just the values of the `ArgMatches`, rather than the entire struct.

So that when running:
```sh
./target/debug/bifrost load [--auto | --modified] ARG1 ARG2
```
The output has changed from

#### Before:
```rust
[STUB] command::load() contents: ArgMatches {
    args: {
        "contents": MatchedArg {
            occurs: 2,
            indices: [
                1,
                2
            ],
            vals: [
                "ARG1",
                "ARG2"
            ]
        }
    },
    subcommand: None,
    usage: Some(
        "USAGE:\n    \n    bifrost load [OPTIONS] <contents>\n    bifrost load [OPTIONS] project/\n    bifrost load [OPTIONS] main.c avl.c bst.c\n"
    )
}
```
to
#### Now:
```rust
[STUB] command::load() contents: Some(Values { iter: Map { iter: Iter(["ARG1", "ARG2"]) } })
```