### PR TITLE
completion of initial impl of bifrost load

### DIFF
--- a/src/bifrost/core/mod.rs
+++ b/src/bifrost/core/mod.rs
@@ -1,5 +1,5 @@
 pub mod app;
 pub mod config;
 pub mod hofund;
-pub mod working_dir;
+pub mod workingdir;
 pub mod workspace;

--- a/src/bifrost/core/workspace.rs
+++ b/src/bifrost/core/workspace.rs
@@ -1,32 +1,30 @@
-//! Primary structures, mehtods, and functions that support `bifrost::ops`.
+//! Primary structures, mehtods, and functions that facilitate `bifrost::ops`.
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process;
 
-use crate::core::config::{values_of, Config};
-use crate::core::working_dir::WorkingDir;
-use crate::util::BifrostResult;
+use crate::core::config::{self, Config};
+use crate::core::workingdir::WorkingDir;
+use crate::util::{BifrostPath, BifrostResult, OperationInfo};
 use crate::ArgMatches;
 
 /// Primary structure which `bifrost::ops operate upon.
 ///
 /// A `WorkSpace` is composed of the following:
-/// * name - the name of a realm's `WorkSpace`.
-/// * mode - describes how `contents` of this `WorkSpace` should be handled.
+/// * name - the name of a Bifrost realm's `WorkSpace`.
+/// * mode - describes _how_ `contents` of this `WorkSpace` should be handled.
 /// * config - a [`Config`](struct.Config.html)
 /// * contents - an `Option<Vec<WorkingDir>>`, see [`WorkingDir`](struct.WorkingDir.html)
 #[derive(Debug)]
 pub struct WorkSpace {
-    // name of workspace that helps keep track of multiple `WorkSpace`'s.
+    // Name of workspace that helps keep track of multiple `WorkSpace`'s.
     name: Option<String>,
-    // mode describing _how_ and/or _which_ operations should be performed.
+    // Mode describing _how_ operations should be performed.
     mode: Mode,
-    // configuration information that describes the current Bifrost realm.
+    // Configuration information that describes the current Bifrost realm.
     config: Config,
-    // contents of the `WorkSpace` in the form of `WorkingDir`s.
+    // Contents of the `WorkSpace` in the form of `WorkingDir`s.
     contents: Option<Vec<WorkingDir>>,
-    // a `BifrostPath` which is a light wrapper around a `PathBuf`.
-    bifrost_path: Option<BifrostPath>,
 }
 
 /// A default `WorkSpace` is constructed with a default `Config` in `Mode::Normal`.
@@ -38,58 +36,317 @@ impl Default for WorkSpace {
             mode: Mode::Normal,
             config: Config::default(),
             contents: None,
-            bifrost_path: None,
         }
     }
 }
 
 impl WorkSpace {
-    /// Initializes a `WorkSpace` from a `Config` and `clap::ArgMatches`. If no
-    /// contents were specified, then `ws_args` will be empty. When `ws_args` is
-    /// empty the default behavior is to construct this `WorkSpace`'s contents from
-    /// the current working directory.
-    ///
-    /// If arguments were passed (i.e. through `$ bifrost load --contents main.c`),
-    /// then all arguments present in `ws_args` are processed. Valid path-names
-    /// are converted to `PathBuf`s from which this `WorkSpace`'s contents will
-    /// be constructed.
-    pub fn init(config: Config, args: &ArgMatches) -> Self {
-        let (ws_mode, ws_args) = WorkSpaceBuilder::values_from_args(&args);
+    /// Returns the name of a workspace.
+    pub fn name(&self) -> Option<&String> {
+        self.name.as_ref()
+    }
+
+    /// Returns the `Mode` of a workspace.
+    pub fn mode(&self) -> Mode {
+        self.mode
+    }
+
+    /// Returns the `Config` of a workspace.
+    pub fn config(&self) -> &Config {
+        &self.config
+    }
+
+    /// Returns the contents of a workspace.
+    pub fn contents(&self) -> Option<&Vec<WorkingDir>> {
+        self.contents.as_ref()
+    }
+
+    /// Constructs a `LoadSpace`.
+    pub fn to_load_space(config: Config, args: &ArgMatches) -> LoadSpace {
+        WorkSpaceArgs::parse(config, &args).to_load_space()
+    }
+}
+
+impl AsMut<WorkSpace> for WorkSpace {
+    fn as_mut(&mut self) -> &mut WorkSpace {
+        self
+    }
+}
+
+/// The `Mode` specifiecs _how_ operations should be performed. A `WorkSpace`'s
+/// contents will be handled differently based on this value (e.g. if `--auto` has
+/// been specified then changes to source files will be detected and be automatically
+/// re-`load`ed).
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum Mode {
+    Auto,
+    Modified,
+    Normal,
+}
+
+/// This structure is similar to `WorkSpace`; however, there are a few differences.
+/// Namely, `ignore_list` and `contents`. The `ignore_list` does not appear in `WorkSpace`
+/// and `contents` is a optional `Vec<String>` instead of a `Vec<WorkingDir>`.
+///
+/// The reason for this is `WorkSpaceArgs` takes values from command line arguments
+/// in the form of `ArgMatches` and from the `Config`. The value(s) of `contents` when
+/// passed from the command line may not be appropriate values to construct `WorkingDir`s.
+///
+/// The `contents` are kept as strings until they have been processed to a point where
+/// they are okay to use; processing may not be able to produce valid `contents`. In this
+/// case, it is best to avoid constructing anything that is `BifrostOperable` or whose
+/// owner is `BifrostOperable`.
+///
+/// New `WorkingDir`s take ownership of a copy of the `ignore_list` when they are constructed.
+/// In previous iterations `WorkSpace`s owned an `ignore_list`. This way eliminates this one
+/// small duplication.
+struct WorkSpaceArgs {
+    name: Option<String>,
+    mode: Mode,
+    config: Config,
+    contents: Option<Vec<String>>,
+    ignore_list: Vec<String>,
+}
+
+impl WorkSpaceArgs {
+    /// Gets the mode, contents, name, and ignore_list from `ArgMatches` and a `Config`.
+    fn parse(config: Config, args: &ArgMatches) -> WorkSpaceArgs {
+        let (ws_mode, ws_contents) = WorkSpaceBuilder::values_from_args(&args);
         let (ws_name, ws_ignore_list) = WorkSpaceBuilder::values_from_config(&config);
 
-        let mut contents: Vec<WorkingDir> = Vec::new();
-        if ws_args.is_empty() {
-            contents.push(WorkingDir::new(config.cwd()).ignore(&ws_ignore_list));
-        } else {
-            let paths = WorkSpaceBuilder::args_to_paths(&config, ws_args);
-
-            if paths.is_empty() {
-                eprintln!("error: contents were passed but no arguments represent valid content");
-                process::exit(1);
-            }
-
-            for path in paths {
-                contents.push(WorkingDir::new(path).ignore(&ws_ignore_list));
-            }
-        }
-
-        WorkSpace {
+        WorkSpaceArgs {
             name: Some(ws_name),
             mode: ws_mode,
             config,
-            contents: Some(contents),
+            contents: Some(ws_contents),
+            ignore_list: ws_ignore_list,
+        }
+    }
+
+    /// Constructs a `LoadSpace` for `WorkSpaceArgs`. `WorkSpaceArgs` has all the
+    /// information needed to construct a `WorkSpace`. The _proposed_ `contents`
+    /// are passed off to `WorkSpaceBuilder::args_to_paths` for some _basic_
+    /// validation/manipulation.
+    ///
+    /// If no paths were returned, then there is nothing to construct `WorkingDir`s from
+    /// and no reason to construct the `WorkSpace`.
+    ///
+    /// Otherwise, a new `WorkSpace` is constructed with new `contents` of type `Vec<WorkingDir>`
+    /// and a `LoadSpace` is returned.
+    fn to_load_space(self) -> LoadSpace {
+        let mut workding_dirs: Vec<WorkingDir> = Vec::new();
+        if let Some(contents) = self.contents {
+            if contents.is_empty() {
+                workding_dirs.push(WorkingDir::new(self.config.cwd()).ignore(&self.ignore_list));
+            } else {
+                let paths = WorkSpaceBuilder::args_to_paths(&self.config, contents, &is_loadable);
+                if paths.is_empty() {
+                    eprintln!(
+                        "error: contents were passed but no arguments represent \
+                         valid current working directory entries"
+                    );
+                    process::exit(1);
+                }
+
+                for path in paths {
+                    workding_dirs.push(WorkingDir::new(path).ignore(&self.ignore_list));
+                }
+            }
+        }
+
+        LoadSpace {
+            workspace: WorkSpace {
+                name: self.name,
+                mode: self.mode,
+                config: self.config,
+                contents: Some(workding_dirs),
+            },
             bifrost_path: None,
         }
     }
 }
 
+pub trait BifrostOperable {
+    /// Prepares implementor to be built.
+    fn prep(&mut self) -> BifrostResult<&mut BifrostOperable>;
+    /// Builds implementor to be executed.
+    fn build(&mut self) -> BifrostResult<&mut BifrostOperable>;
+    /// Executes implementor's executive function(s).
+    fn exec(&mut self) -> BifrostResult<OperationInfo>;
+}
+
+#[derive(Debug)]
+pub struct BaseSpace {}
+
+impl BifrostOperable for BaseSpace {
+    fn prep(&mut self) -> BifrostResult<&mut BifrostOperable> {
+        unimplemented!();
+    }
+
+    fn build(&mut self) -> BifrostResult<&mut BifrostOperable> {
+        unimplemented!();
+    }
+
+    fn exec(&mut self) -> BifrostResult<OperationInfo> {
+        unimplemented!();
+    }
+}
+
+/// Primary data structure used to `load` `WorkSpace`s into the Bifrost container.
+#[derive(Debug)]
+pub struct LoadSpace {
+    /// The `WorkSpace` to be loaded.
+    workspace: WorkSpace,
+    /// The target path to `load` the `WorkSpace` to.
+    bifrost_path: Option<BifrostPath>,
+}
+
+/// A `LoadSpace`'s primary goal is to `load` contents into the Bifrost container.
+/// However, it also implements helper methods that make accessing its nested
+/// structure a little more ergonomic at this level.
+impl LoadSpace {
+    /// Returns a reference to the underlying `WorkSpace`.
+    pub fn workspace(&self) -> &WorkSpace {
+        &self.workspace
+    }
+
+    /// Returns a reference to the underlying `home_path` `PathBuf` defined
+    /// upon configuration.
+    pub fn home_path(&self) -> &PathBuf {
+        self.workspace.config().home_path()
+    }
+
+    /// Returns a optional reference to the underlying `WorkSpace` name.
+    pub fn name(&self) -> Option<&String> {
+        self.workspace.name()
+    }
+
+    /// Returns a `clone`d version of the target `BifrostPath`.
+    pub fn bifrost_path(&self) -> Option<BifrostPath> {
+        self.bifrost_path.clone()
+    }
+
+    /// Returns the underlying `WorkSpace`'s contents `as_mut`.
+    pub fn contents_as_mut(&mut self) -> Option<&mut Vec<WorkingDir>> {
+        self.workspace.contents.as_mut()
+    }
+
+    /// Returns the underlying `WorkSpace` `as_mut`.
+    pub fn workspace_as_mut(&mut self) -> &mut WorkSpace {
+        self.workspace.as_mut()
+    }
+
+    /// Loads this spaces's `WorkSpace` to the target `BifrostPath`.
+    ///
+    /// # Panics
+    ///
+    /// * if the call to [`prep`] has failed or
+    /// * if it cannot unwrap a `WorkSpace::name`
+    ///
+    /// It is possible that this method **panics**, however, this means
+    /// that this method was called prior to a call to [`prep`] or that
+    /// the call to [`prep`] failed.
+    ///
+    /// It might be possible for this method to attempt to unwrap a `WorkSpace::name`
+    /// that is `None`. This seems **unlikely**, however, this can be ruled out if
+    /// it can be shown that `WorkSpace::default` is the only operation that
+    /// produces a `WorkSpace` with a name that is `None`.
+    pub fn load(&mut self) -> BifrostResult<OperationInfo> {
+        let mut nbytes = 0u64;
+        let path = self
+            .bifrost_path()
+            .expect("BUG: `BifrostPath` should not be `None` here");
+
+        // The contents must be mutable because loading a `WorkingDir`
+        // mutates its underlying `dirs` field.
+        if let Some(contents) = self.contents_as_mut() {
+            for wd in contents {
+                let info = wd.load(path.clone())?;
+                if let Some(n) = info.bytes {
+                    nbytes += n;
+                }
+            }
+        }
+
+        // The name really should not be `None` at this point.
+        let name = self
+            .name()
+            .expect("BUG: `LoadSpace::load` failed to unwrap `WorkSpace::name`")
+            .clone();
+
+        // Returns the sum of bytes written and the name of the workspace they
+        // were written from.
+        Ok(OperationInfo {
+            bytes: Some(nbytes),
+            name,
+        })
+    }
+}
+
+/// Implements `BifrostOperable` for `LoadSpace`.
+/// A `LoadSpace` is `prep`-able, `build`-able, and `exec`-utable. These methods
+/// follow a builder-esq pattern. They are meant to be called in sequence (chained).
+/// Both `prep` and `build` return `BifrostResult`s containing structures that implement
+/// `BifrostOperable` (or errors). Conversely, `build` is a consuming operation that
+/// returns a `BifrostResult` containing the `OperationInfo`.
+///
+/// # Examples
+///
+/// ```compile_fail
+/// // Both `prep` and `build` return `BifrostResult`s containing structures that
+/// // implement `BifrostOperable`.
+/// let bifrost_operable = WorkSpace::to_load_space(config, &args)
+///        .prep()?
+///        .build()?;
+///
+/// // Conversely, `exec` is a consuming operation and returns a `BifrostResult`
+/// // containing the `OperationInfo` (i.e. number of bytes written).
+/// let operation_info = WorkSpace::to_load_space(config, &args)
+///        .prep()?
+///        .build()?
+///        .exec()?;
+/// ```
+impl BifrostOperable for LoadSpace {
+    /// Prepares a `LoadSpace` by ensuring that its target destination (`BifrostPath`)
+    /// does not already exist. Reassigns `self.bifrost_path` if and only if the
+    /// `BifrostPath` is unique.
+    fn prep(&mut self) -> BifrostResult<&mut BifrostOperable> {
+        if self.bifrost_path().is_some() {
+            failure::bail!("error: a `BifrostPath` has already been prepared for this `LoadSpace`");
+        }
+        self.bifrost_path = Some(BifrostPath::new(self.home_path(), self.name())?);
+        Ok(self)
+    }
+
+    /// Builds a `LoadSpace` by calling `walk` on each underlying `WorkingDir` owned
+    /// by the workspace's contents. Reassigns `self.workspace.contents` if and only if
+    /// each `walk` was successful.
+    fn build(&mut self) -> BifrostResult<&mut BifrostOperable> {
+        if let Some(contents) = self.workspace.contents.as_mut() {
+            let mut walked_content: Vec<WorkingDir> = vec![];
+            while let Some(entry) = contents.pop() {
+                let wd = entry.walk()?;
+                walked_content.push(wd);
+            }
+            self.workspace.contents = Some(walked_content)
+        }
+        Ok(self)
+    }
+
+    /// Executes a `LoadSpace`'s primary function: `load`.
+    fn exec(&mut self) -> BifrostResult<OperationInfo> {
+        Ok(self.load()?)
+    }
+}
+
+/// A no-field struct used to signal a division of labor/responsibility.
 struct WorkSpaceBuilder;
 
 impl WorkSpaceBuilder {
     // Returns the ignore list from the manifest if it exists. Otherwise, an
     // empty vector will be returned meaning that no files will be ignored in
     // the `WorkSpace`.
-    fn build_workspace_ignore_list(config: &Config) -> Vec<String> {
+    fn get_workspace_ignore_list(config: &Config) -> Vec<String> {
         match config
             .manifest()
             .and_then(|m| m.workspace_config().and_then(|ws| ws.ignore()))
@@ -133,7 +390,7 @@ impl WorkSpaceBuilder {
     fn values_from_args(args: &ArgMatches) -> (Mode, Vec<String>) {
         (
             flag(&args),
-            values_of("contents", &args).map_or(vec![], |v| v),
+            config::values_of("contents", &args).map_or(vec![], |v| v),
         )
     }
 
@@ -142,7 +399,7 @@ impl WorkSpaceBuilder {
     fn values_from_config(config: &Config) -> (String, Vec<String>) {
         (
             WorkSpaceBuilder::get_workspace_name(&config),
-            WorkSpaceBuilder::build_workspace_ignore_list(&config),
+            WorkSpaceBuilder::get_workspace_ignore_list(&config),
         )
     }
 
@@ -150,44 +407,52 @@ impl WorkSpaceBuilder {
     // `check`s if the current working directory has paths that contain these arguments,
     // and then returns absolute-path-versions of these arguments.
     // More validation may need to be done; this is a naive implementation.
-    fn args_to_paths(config: &Config, args: Vec<String>) -> Vec<PathBuf> {
+    fn args_to_paths(
+        config: &Config,
+        args: Vec<String>,
+        f: &Fn(&Config, &str) -> BifrostResult<bool>,
+    ) -> Vec<PathBuf> {
         let ws_path_names = strip(&args);
-        let ws_paths = check(config.cwd(), ws_path_names);
-        return to_abs_path(config.cwd(), ws_paths);
+        let ws_paths = check(&config, ws_path_names, f);
+        return to_abs_paths(config.cwd(), ws_paths);
     }
 }
 
-#[derive(Copy, Clone, Debug)]
-enum Mode {
-    Auto,
-    Modified,
-    Normal,
-}
-
-// Collects `names` that can be considered valid paths.
-fn check<P>(cwd: P, names: Vec<String>) -> Vec<String>
-where
-    P: AsRef<Path>,
-{
+// Collects `names` that can be considered valid paths for a given operation. If
+// the `BifrostResult` returned by `f` cannot be unwrapped then the value an `Ok`
+// result would have contained is considered to be false.
+fn check(
+    config: &Config,
+    names: Vec<String>,
+    f: &Fn(&Config, &str) -> BifrostResult<bool>,
+) -> Vec<String> {
     names
         .into_iter()
-        .filter(|n| is_valid(&cwd, n).unwrap_or(false))
+        .filter(|n| f(&config, n).unwrap_or(false))
         .collect()
 }
 
 // A `name` is valid if it exists within the current Bifrost realm.
-fn is_valid<P>(cwd: P, name: &str) -> BifrostResult<bool>
-where
-    P: AsRef<Path>,
-{
-    for entry in fs::read_dir(cwd)? {
+fn is_loadable(config: &Config, name: &str) -> BifrostResult<bool> {
+    // Home or root paths are not loadable.
+    if config.home_path().as_path() == Path::new(name) {
+        return Ok(false);
+    }
+
+    // A path that already contains .bifrost or container is not loadable.
+    if name.contains(".biforst") || name.contains("container") {
+        return Ok(false);
+    }
+
+    // A `name` must exist within the current working directory in order for
+    // it to be loadable.
+    for entry in fs::read_dir(config.cwd())? {
         let entry = entry?;
-        if let Some(path) = entry.path().to_str() {
-            if path.contains(name) {
-                return Ok(true);
-            }
+        if entry.file_name() == name {
+            return Ok(true);
         }
     }
+    // No other cases are loadable.
     Ok(false)
 }
 
@@ -202,7 +467,7 @@ fn strip(names: &Vec<String>) -> Vec<String> {
 
 // Returns a `name` without any trailing slashes.
 fn strip_trailing_slash(name: &str) -> &str {
-    if name.len() > 1 && name.ends_with("\\") || name.ends_with("/") {
+    if name.len() > 1 && (name.ends_with("\\") || name.ends_with("/")) {
         return &name[..name.len() - 1];
     }
     name
@@ -210,18 +475,22 @@ fn strip_trailing_slash(name: &str) -> &str {
 
 // Converts `name`d strings to `PathBuf`s if and only if the name is contained
 // within a `PathBuf` that resides in the current working directory.
-fn to_abs_path<P>(cwd: P, paths: Vec<String>) -> Vec<PathBuf>
+fn to_abs_paths<P>(cwd: P, paths: Vec<String>) -> Vec<PathBuf>
 where
     P: AsRef<Path>,
 {
     let mut abs_paths: Vec<PathBuf> = Vec::new();
+    if paths.is_empty() {
+        return abs_paths;
+    }
+
     if let Ok(read_dir) = fs::read_dir(cwd) {
         for entry in read_dir {
-            if let Ok(e) = entry {
-                if let Some(s) = e.path().to_str() {
-                    if paths.iter().any(|p| **p == *s || s.contains(p)) {
-                        abs_paths.push(e.path().to_path_buf());
-                    }
+            let entry =
+                entry.expect("BUG: `BifrostPath::check` passed but `to_abs_paths` has failed");
+            for name in paths.iter() {
+                if entry.file_name() == name[..] {
+                    abs_paths.push(entry.path())
                 }
             }
         }
@@ -239,15 +508,95 @@ fn flag(args: &ArgMatches) -> Mode {
     Mode::Normal
 }
 
-/// A light wrapper around a `PathBuf`. This structure exists to deter improper
-/// command execution. That is, `bifrost::ops` require target paths to be `BifrostPath`s
-/// in order to prevent operations from being performed on arbitrary `PathBuf`s.
-///
-/// For example, it should not be possible for a user to remove their entire
-/// home directory (or another arbitrary directory). Moreover, the goal of `BifrostPath`
-/// is to validate and enforce invariants on paths that `load`, `unload`, and
-/// `show` will use as targets.
-#[derive(Debug)]
-pub struct BifrostPath {
-    path: PathBuf,
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_default_workspace() {
+        let ws = WorkSpace::default();
+        let msg = "BUG: `WorkSpace::default` succeeds but `test_default_workspace` fails to";
+        let home_path = dirs::home_dir().expect(&format!("{} {}", msg, "unwrap `dirs::home_dir`"));
+        let cwd = std::env::current_dir()
+            .expect(&format!("{} {}", msg, "unwrap `std::env::current_dir`"));
+
+        assert_eq!(home_path, *ws.config.home_path());
+        assert_eq!(cwd, *ws.config.cwd());
+        assert_eq!(Mode::Normal, ws.mode);
+        assert!(ws.name.is_none() && ws.contents.is_none());
+    }
+
+    #[test]
+    fn test_to_abs_paths() {
+        let names: Vec<String> = vec![
+            String::from("file.txt"),
+            String::from("file.cpp"),
+            String::from("test_dir_nested"),
+            String::from("test_ignore_file.txt"),
+            String::from("file.c"),
+            String::from("file.rs"),
+            // Not valid
+            String::from("random"),
+            // Not valid
+            String::from("not in dir"),
+        ];
+
+        const LEFT: usize = 6;
+        let abs_paths = to_abs_paths("tests/test_dir", names);
+        assert_eq!(LEFT, abs_paths.len());
+
+        let abs_paths = to_abs_paths("tests/test_dir", vec![]);
+        assert!(abs_paths.is_empty());
+    }
+
+    #[test]
+    fn test_strip_trailing_slash() {
+        let n0 = "";
+        assert_eq!(n0, strip_trailing_slash(n0));
+
+        let n1 = "/";
+        assert_eq!(n1, strip_trailing_slash(n1));
+
+        let n2 = "src/";
+        assert_eq!("src", strip_trailing_slash(n2));
+
+        let n3 = r#"src\"#;
+        assert_eq!("src", strip_trailing_slash(n3));
+    }
+
+    #[test]
+    fn test_strip() {
+        let left: Vec<String> = vec![
+            String::from(""),
+            String::from("/"),
+            String::from("src/"),
+            String::from(r#"src\"#),
+        ];
+
+        let right = strip(&left);
+        assert_eq!(left.len(), right.len());
+    }
+
+    // figure out how to run this test
+    fn _test_is_loadable() -> BifrostResult<()> {
+        let current_dir = std::env::current_dir()?;
+        let test_path = Path::new("tests").join("test_dir");
+        std::env::set_current_dir(test_path)?;
+        let config = Config::default();
+        let mut entries: Vec<String> = vec![];
+        for e in fs::read_dir(config.cwd())? {
+            let e = e?;
+            let fname = e.file_name();
+            let s = fname
+                .into_string()
+                .expect("error: test_is_loadable failed to convert `file_name` `into_string`");
+            entries.push(s);
+        }
+
+        for e in entries {
+            assert!(is_loadable(&config, &e)?);
+        }
+        std::env::set_current_dir(current_dir)?;
+        Ok(())
+    }
 }

--- a/src/bifrost/ops/bifrost_init.rs
+++ b/src/bifrost/ops/bifrost_init.rs
@@ -48,20 +48,43 @@ cmd = ["command string(s)"]
 
     if fs::metadata(&config.cwd().join("Bifrost.toml")).is_ok() {
         io::stderr().write(
-            "error: `bifrost init` cannot be run on an existing Bifrost realm\n".as_bytes(),
+            "error: `bifrost init` cannot be run on an existing bifrost realm\n".as_bytes(),
         )?;
         process::exit(1);
     }
 
     let success = |p: &std::path::PathBuf| -> BifrostResult<()> {
         io::stdout().write_fmt(format_args!(
-            "Initialized default Bifrost realm in {}\n",
+            "initialized default bifrost realm in {}\n",
             p.display()
         ))?;
         Ok(())
     };
 
     if args.args.is_empty() {
+        let name = config
+            .cwd()
+            .file_name()
+            .expect("msg: &str")
+            .to_str()
+            .expect("BUG: `bifrost::init` failed to convert cwd name `to_str`");
+        let toml: &str = &format!(
+            r#"[project]
+name = "project name"
+
+[container]
+name = "docker"
+
+[workspace]
+name = "{}"
+ignore = ["target", ".git", ".gitignore"]
+
+[command]
+cmd = ["command string(s)"]
+"#,
+            name
+        );
+
         hofund::write(&config.cwd().join("Bifrost.toml"), &toml.as_bytes())?;
         success(config.cwd())?;
     } else {
@@ -71,8 +94,8 @@ cmd = ["command string(s)"]
                 Ok(s) => s,
                 Err(e) => {
                     io::stderr().write_fmt(format_args!(
-                        "warn: failed to convert Bifrost manifest \
-                         to string due to `{}` used default instead",
+                        "warn: failed to convert bifrost manifest \
+                         to string due to `{}` ...used default instead",
                         e
                     ))?;
                     String::from(toml)

--- a/src/bifrost/ops/bifrost_load.rs
+++ b/src/bifrost/ops/bifrost_load.rs
@@ -1,89 +1,29 @@
 //! Implementation details of the `load` subcommand.
+use std::io::{self, Write};
 
 use crate::core::config::Config;
-use crate::core::workspace::WorkSpace;
-use crate::util::BifrostResult;
+use crate::core::workspace::{BifrostOperable, WorkSpace};
+use crate::util::{BifrostResult, OperationInfo};
 use crate::ArgMatches;
 
 /// Loads a Bifrost Workspace. Utilizes `Config` and `ArgMatches` to construct
 /// a `WorkSpace`. This workspace is then loaded to the target directory specified
 /// by a `BifrostPath`. Here, **load** is synonymous with **copy**.
 pub fn load(config: Config, args: &ArgMatches) -> BifrostResult<()> {
-    let ws = WorkSpace::init(config, &args);
-    Ok(())
+    let success = |op_info: &OperationInfo| -> BifrostResult<()> {
+        io::stdout().write_fmt(format_args!(
+            "loaded `{}` bytes from workspace realm `{}`\n",
+            op_info.bytes.unwrap(),
+            op_info.name,
+        ))?;
+        Ok(())
+    };
+
+    let op_info = WorkSpace::to_load_space(config, &args)
+        .prep()?
+        .build()?
+        .exec()?;
+
+    success(&op_info)?;
+    return Ok(());
 }
-
-/*
-fn load<P>(wd: &mut WorkingDir, to: P) -> Result<u64>
-    where
-        P: AsRef<Path>,
-{
-    let parent = wd
-        .parent
-        .as_ref()
-        .map(|p| p.to_str().unwrap_or(""))
-        .unwrap();
-
-    // `dirs` will be empty after this if block.
-    if let Some(from) = wd.dirs.pop() {
-        if let Ok(path) = load_top_level_dir(&parent, &from, &to) {
-            wd.unload_path = path;
-        }
-        while let Some(from) = wd.dirs.pop() {
-            load_dir(&parent, &from, &to)?;
-        }
-    }
-    return load_files(&parent, &wd, &to);
-}
-
-/// Load the top-level directory `to` its target destination. This will be the
-/// path that this `WorkingDir` will be `unload`ed from.
-fn load_top_level_dir<P>(parent: &str, from: &DirEntryExt, to: P) -> Result<UnloadPath>
-    where
-        P: AsRef<Path>,
-{
-    let mut t = to.as_ref().to_path_buf();
-    let to_dir = from.0.path().clone();
-    if let Ok(to_dir) = to_dir.strip_prefix(parent) {
-        t.push(to_dir);
-        fs::create_dir_all(&t)?;
-        return Ok(UnloadPath(Some(t)));
-    }
-    Ok(UnloadPath(None))
-}
-
-fn load_dir<P>(parent: &str, from: &DirEntryExt, to: P) -> Result<()>
-    where
-        P: AsRef<Path>,
-{
-    let mut t = to.as_ref().to_path_buf();
-    let to_dir = from.0.path().clone();
-    if let Ok(to_dir) = to_dir.strip_prefix(parent) {
-        t.push(to_dir);
-        fs::create_dir_all(&t)?;
-    }
-    Ok(())
-}
-
-fn load_files<P>(parent: &str, wd: &WorkingDir, to: P) -> Result<u64>
-    where
-        P: AsRef<Path>,
-{
-    let mut nbytes = 0;
-    for entry in &wd.files {
-        let to = to.as_ref().to_path_buf();
-
-        if let Ok(to) = entry.strip_prefix(parent).map(|e| to.join(e)) {
-            File::create(&to)?;
-            if let Ok(n) = fs::copy(entry, to) {
-                nbytes += n;
-            }
-        }
-    }
-    Ok(nbytes)
-}
-
-fn unload(path: UnloadPath) -> Result<()> {
-    unimplemented!();
-}
-*/

--- a/src/bifrost/util/mod.rs
+++ b/src/bifrost/util/mod.rs
@@ -1,6 +1,77 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
 use failure;
 
 pub type BifrostResult<T> = failure::Fallible<T>;
+
+/// A light wrapper around a `PathBuf`. This structure exists to deter improper
+/// command execution. That is, `bifrost::ops` require target paths to be `BifrostPath`s
+/// in order to prevent operations from being performed on arbitrary `PathBuf`s.
+///
+/// For example, it should not be possible for a user to remove (e.g. `unload`) their entire
+/// home directory (or another arbitrary directory). Moreover, the goal of `BifrostPath`
+/// is to validate and enforce invariants on paths that `load`, `unload`, and
+/// `show` use as targets.
+#[derive(Debug)]
+pub struct BifrostPath {
+    pub path: PathBuf,
+}
+
+impl Clone for BifrostPath {
+    fn clone(&self) -> Self {
+        BifrostPath {
+            path: self.path.to_path_buf(),
+        }
+    }
+}
+
+/// Wrapper around a `PathBuf` used to construct paths that enforce the following invariants:
+///
+/// * the path does not contain black-listed names
+/// * the path is unique meaning that it does not currently exist within the Bifrost container
+impl BifrostPath {
+    /// Constructs a new `BifrostPath` from a home directory path and a workspace's
+    /// name.
+    pub fn new(home_path: &Path, name: Option<&String>) -> BifrostResult<Self> {
+        // Check that the name is not blacklisted.
+        BifrostPath::check(name)?;
+
+        // Construct path to the Bifrost container.
+        let container_path = home_path.join(".bifrost").join("container");
+        // Construct path to this workspace's destination within the Bifrost container.
+        let path =
+            container_path.join(name.expect("BUG: `WorkSpace::name` should not be `None` here"));
+
+        // Bail if the path already exists.
+        if fs::metadata(&path).is_ok() {
+            failure::bail!("error: the proposed path {:#?} already exists", path);
+        }
+
+        Ok(BifrostPath { path })
+    }
+
+    /// Checks that the `proposed_name` does not contain any black-listed names.
+    fn check(proposed_name: Option<&String>) -> BifrostResult<()> {
+        let black_list: Vec<&str> = vec![".bifrost", "container", ".bifrost_config", "tmp"];
+
+        if let Some(name) = proposed_name {
+            if black_list.iter().any(|b| *b == name) {
+                failure::bail!("error: proposed path contains blacklisted name(s)");
+            }
+        } else {
+            failure::bail!("error: proposed path cannot be empty or `None`");
+        }
+
+        // The `path` checks good!
+        Ok(())
+    }
+}
+
+pub struct OperationInfo {
+    pub bytes: Option<u64>,
+    pub name: String,
+}
 
 #[macro_use]
 mod macros;


### PR DESCRIPTION
This PR completes the initial work for the `$ bifrost load` command.

Some restructuring was required and the intent was to ensure that the remaining `bifrost::ops` can be implemented without changes to `bifrost::core`.

There may still be some unforeseen changes that must be made, however, I'm trying to solidify the base enough so that subsequent PRs can be localized within a single module when implementing the remaining `bifrost::ops`.

The highlight of this PR is the introduction of the following trait:

```rust
pub trait BifrostOperable {
    /// Prepares implementor to be built.
    fn prep(&mut self) -> BifrostResult<&mut BifrostOperable>;
    /// Builds implementor to be executed.
    fn build(&mut self) -> BifrostResult<&mut BifrostOperable>;
    /// Executes implementor's executive function(s).
    fn exec(&mut self) -> BifrostResult<OperationInfo>;
}
```

Now, a `WorkSpace` is contained within a space that implements `BifrostOperable` (e.g. `LoadSpace`).

The idea is to map bifrost commands (load, unload, run, show) to types. That is, a `WorkSpace` should be as general as possible and the owning type should specify specialized behavior.

For example, 
* `$ bifrost load` should only operate on workspaces that are loadable
* `$ bifrost show` should only operate on workspaces that are showable, etc